### PR TITLE
use blendMode parameter in applyGradientColors()

### DIFF
--- a/AFImageHelper/AFImageExtension.swift
+++ b/AFImageHelper/AFImageExtension.swift
@@ -91,7 +91,7 @@ public extension UIImage {
         let context = UIGraphicsGetCurrentContext()
         CGContextTranslateCTM(context, 0, size.height)
         CGContextScaleCTM(context, 1.0, -1.0)
-        CGContextSetBlendMode(context, CGBlendMode.Normal)
+        CGContextSetBlendMode(context, blendMode)
         let rect = CGRect(x: 0, y: 0, width: size.width, height: size.height)
         CGContextDrawImage(context, rect, self.CGImage)
         // Create gradient


### PR DESCRIPTION
Blend mode was always set to .Normal because the blendMode parameter was never used in the function.